### PR TITLE
Add duplicate message management

### DIFF
--- a/Ardupilog.m
+++ b/Ardupilog.m
@@ -324,7 +324,15 @@ classdef Ardupilog < dynamicprops & matlab.mixin.Copyable
                     warning('Msg group %d/%s could not be created', newType, newName);
                 else
                     obj.msgsContained{end+1} = newName;
+                    try 
                     addprop(obj, newName);
+                    catch ME
+                        if strcmp(ME.identifier,'MATLAB:class:PropertyInUse')
+                            warning('Duplicate message %d/%s definition', newType, newName);
+                        else
+                            rethrow(ME);
+                        end
+                    end
                     obj.(newName) = new_msg_group;
                 end
                


### PR DESCRIPTION
Hi Matt,
With a new Ardupilot drone I'm using, I've noticed that the script is crashing with duplicated FMT messages. I've found a solution in the original repository of Ardupilog.